### PR TITLE
Return Range-compatible Array from rangeFromLineNumber

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,3 @@
 {
-  "extends": "steelbrain",
-  "rules": {
-    "no-duplicate-imports": "off"
-  }
+  "extends": "steelbrain"
 }

--- a/spec/helper-spec.js
+++ b/spec/helper-spec.js
@@ -27,9 +27,9 @@ describe('linter helpers', function () {
       waitsForAsync(async function () {
         await atom.workspace.open(somethingFile)
         const textEditor = atom.workspace.getActiveTextEditor()
-        expect(rangeFromLineNumber(textEditor).serialize()).toEqual([[0, 0], [0, 30]])
-        expect(rangeFromLineNumber(textEditor, -1).serialize()).toEqual([[0, 0], [0, 30]])
-        expect(rangeFromLineNumber(textEditor, 'a').serialize()).toEqual([[0, 0], [0, 30]])
+        expect(rangeFromLineNumber(textEditor)).toEqual([[0, 0], [0, 30]])
+        expect(rangeFromLineNumber(textEditor, -1)).toEqual([[0, 0], [0, 30]])
+        expect(rangeFromLineNumber(textEditor, 'a')).toEqual([[0, 0], [0, 30]])
       })
     )
 
@@ -37,8 +37,8 @@ describe('linter helpers', function () {
       waitsForAsync(async function () {
         await atom.workspace.open(somethingFile)
         const textEditor = atom.workspace.getActiveTextEditor()
-        expect(rangeFromLineNumber(textEditor, 7, -1).serialize()).toEqual([[7, 0], [7, 43]])
-        expect(rangeFromLineNumber(textEditor, 7, 'a').serialize()).toEqual([[7, 0], [7, 43]])
+        expect(rangeFromLineNumber(textEditor, 7, -1)).toEqual([[7, 0], [7, 43]])
+        expect(rangeFromLineNumber(textEditor, 7, 'a')).toEqual([[7, 0], [7, 43]])
       })
     )
 
@@ -46,7 +46,7 @@ describe('linter helpers', function () {
       waitsForAsync(async function () {
         await atom.workspace.open(somethingFile)
         const textEditor = atom.workspace.getActiveTextEditor()
-        const range = helpers.rangeFromLineNumber(textEditor, 7).serialize()
+        const range = helpers.rangeFromLineNumber(textEditor, 7)
         expect(range).toEqual([[7, 0], [7, 43]])
       })
     )
@@ -55,7 +55,7 @@ describe('linter helpers', function () {
       waitsForAsync(async function () {
         await atom.workspace.open(somethingFile)
         const textEditor = atom.workspace.getActiveTextEditor()
-        const range = helpers.rangeFromLineNumber(textEditor, 7, 4).serialize()
+        const range = helpers.rangeFromLineNumber(textEditor, 7, 4)
         expect(range).toEqual([[7, 4], [7, 11]])
       })
     )
@@ -84,10 +84,10 @@ describe('linter helpers', function () {
       waitsForAsync(async function () {
         await atom.workspace.open(mixedIndentFile)
         const textEditor = atom.workspace.getActiveTextEditor()
-        expect(helpers.rangeFromLineNumber(textEditor, 0).serialize()).toEqual([[0, 0], [0, 3]])
-        expect(helpers.rangeFromLineNumber(textEditor, 1).serialize()).toEqual([[1, 2], [1, 5]])
-        expect(helpers.rangeFromLineNumber(textEditor, 2).serialize()).toEqual([[2, 1], [2, 4]])
-        expect(helpers.rangeFromLineNumber(textEditor, 3).serialize()).toEqual([[3, 2], [3, 5]])
+        expect(helpers.rangeFromLineNumber(textEditor, 0)).toEqual([[0, 0], [0, 3]])
+        expect(helpers.rangeFromLineNumber(textEditor, 1)).toEqual([[1, 2], [1, 5]])
+        expect(helpers.rangeFromLineNumber(textEditor, 2)).toEqual([[2, 1], [2, 4]])
+        expect(helpers.rangeFromLineNumber(textEditor, 3)).toEqual([[3, 2], [3, 5]])
       })
     )
 
@@ -95,10 +95,10 @@ describe('linter helpers', function () {
       waitsForAsync(async function() {
         await atom.workspace.open(mixedIndentFile)
         const textEditor = atom.workspace.getActiveTextEditor()
-        expect(helpers.rangeFromLineNumber(textEditor, 0, 0).serialize()).toEqual([[0, 0], [0, 3]])
-        expect(helpers.rangeFromLineNumber(textEditor, 1, 0).serialize()).toEqual([[1, 0], [1, 5]])
-        expect(helpers.rangeFromLineNumber(textEditor, 2, 0).serialize()).toEqual([[2, 0], [2, 4]])
-        expect(helpers.rangeFromLineNumber(textEditor, 3, 0).serialize()).toEqual([[3, 0], [3, 5]])
+        expect(helpers.rangeFromLineNumber(textEditor, 0, 0)).toEqual([[0, 0], [0, 3]])
+        expect(helpers.rangeFromLineNumber(textEditor, 1, 0)).toEqual([[1, 0], [1, 5]])
+        expect(helpers.rangeFromLineNumber(textEditor, 2, 0)).toEqual([[2, 0], [2, 4]])
+        expect(helpers.rangeFromLineNumber(textEditor, 3, 0)).toEqual([[3, 0], [3, 5]])
       })
     })
   })

--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,8 @@
 
 import * as Path from 'path'
 import * as FS from 'fs'
-import { Range } from 'atom'
 import { exec, execNode } from 'sb-exec'
-import type { TextEditor } from 'atom'
+import type { TextEditor, Range } from 'atom'
 import * as Helpers from './helpers'
 import type { TempFiles } from './types'
 
@@ -47,10 +46,10 @@ export function rangeFromLineNumber(textEditor: TextEditor, line: ?number, colum
     throw new Error(`Column start (${colStart || 0}) greater than line length (${lineText.length}) for line ${lineNumber}`)
   }
 
-  return Range.fromObject([
+  return [
     [lineNumber, colStart],
     [lineNumber, colEnd],
-  ])
+  ]
 }
 
 export async function findAsync(directory: string, name: string | Array<string>): Promise<?string> {


### PR DESCRIPTION
It turns out that the required import of the Range object is breaking in worker processes for some providers. Move back to a Range-compatible Array in order to remove this requirement.

Fixes https://github.com/AtomLinter/linter-eslint/issues/765.