### PR TITLE
Use rimraf for cross-platform clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "(flow check) && (eslint .)",
     "test": "apm test",
-    "clean": "rm -rf lib",
+    "clean": "rimraf lib",
     "compile": "npm run clean && babel src --out-dir lib",
     "watch": "npm run clean && babel src --out-dir lib --watch"
   },
@@ -35,6 +35,7 @@
     "babel-preset-steelbrain": "^4.0.1",
     "eslint-config-steelbrain": "^1.0.4",
     "flow-bin": "^0.31.1",
-    "jasmine-fix": "^1.0.1"
+    "jasmine-fix": "^1.0.1",
+    "rimraf": "^2.5.4"
   }
 }


### PR DESCRIPTION
The previous script didn't work on Windows. Move to using `rimraf` to delete the folder as it works wherever Node.js does.