### PR TITLE
Deprecate parse method

### DIFF
--- a/decls/jasmine.js
+++ b/decls/jasmine.js
@@ -7,3 +7,4 @@ declare function describe(name: string, callback: (() => void)): void;
 declare function fdescribe(name: string, callback: (() => void)): void;
 declare function beforeEach(callback: (() => void)): void;
 declare function afterEach(callback: (() => void)): void;
+declare function spyOn(object: Object, property: string): any;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1998,6 +1998,11 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "event-kit": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-2.5.3.tgz",
+      "integrity": "sha512-b7Qi1JNzY4BfAYfnIRanLk0DOD1gdkWHT4GISIn8Q2tAf3LpU8SP2CMwWaq40imYoKWbtN4ZhbSRxvsnikooZQ=="
+    },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -2751,6 +2756,14 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
+    },
+    "grim": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/grim/-/grim-2.0.2.tgz",
+      "integrity": "sha512-Qj7hTJRfd87E/gUgfvM0YIH/g2UA2SV6niv6BYXk1o6w4mhgv+QyYM1EjOJQljvzgEj4SqSsRWldXIeKHz3e3Q==",
+      "requires": {
+        "event-kit": "^2.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/steelbrain/atom-linter#readme",
   "dependencies": {
+    "grim": "^2.0.2",
     "named-js-regexp": "^1.3.1",
     "sb-exec": "^4.0.0",
     "sb-promisify": "^2.0.1",

--- a/spec/helper-spec.js
+++ b/spec/helper-spec.js
@@ -4,6 +4,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { execNode } from "sb-exec";
 import { it, wait } from "jasmine-fix";
+import Grim from "grim";
 import { waitsForAsync, waitsForAsyncRejection } from "./spec-helpers";
 import * as helpersOfHelpers from "../src/helpers";
 import * as helpers from "../src/index";
@@ -114,6 +115,11 @@ describe("linter helpers", function() {
   });
 
   describe("::parse", function() {
+    beforeEach(() => {
+      // Disable deprecate warnings in the specs
+      spyOn(Grim, "deprecate").andCallFake(() => {});
+    });
+
     function parse(a: any = undefined, b: any = undefined, c: any = undefined) {
       return helpers.parse(a, b, c);
     }
@@ -135,7 +141,7 @@ describe("linter helpers", function() {
           range: [[0, 0], [0, 0]]
         }
       ];
-      let results = helpers.parse(input, regex, { flags: "i" });
+      let results = parse(input, regex, { flags: "i" });
       expect(results).toEqual(output);
 
       regex = "type:(?<type>.+) message:(?<message>.+)";
@@ -148,7 +154,7 @@ describe("linter helpers", function() {
           range: [[0, 0], [0, 0]]
         }
       ];
-      results = helpers.parse(input, regex, { flags: "gi" });
+      results = parse(input, regex, { flags: "gi" });
       expect(results).toEqual(output);
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@
 import * as Path from "path";
 import * as FS from "fs";
 import { exec, execNode } from "sb-exec";
+import { deprecate } from "grim";
 // eslint-disable-next-line import/no-unresolved
 import type { TextEditor, Range } from "atom";
 import * as Helpers from "./helpers";
@@ -234,6 +235,10 @@ export function parse(
   regex: string,
   givenOptions: { flags?: string, filePath?: string } = {}
 ) {
+  // TODO: Remove this in atom-linter v11.
+  deprecate(
+    "The `parse` method is deprecated and will be removed in the next major release of atom-linter."
+  );
   if (typeof data !== "string") {
     throw new Error("Invalid or no `data` provided");
   } else if (typeof regex !== "string") {


### PR DESCRIPTION
This method has almost always required about as much work as it is doing after you run it to massage the results. There isn't any real point in keeping it around when no maintained provider is using it or is likely to in the future.